### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Synqit-demo/d3a8465c-0048-4c97-94f2-a934ff52129a/9f200d33-3757-4060-b468-0131e94e0e60/_apis/work/boardbadge/3f5ffcd4-ef79-4823-b2fc-f318ebd719e9)](https://dev.azure.com/Synqit-demo/d3a8465c-0048-4c97-94f2-a934ff52129a/_boards/board/t/9f200d33-3757-4060-b468-0131e94e0e60/Microsoft.RequirementCategory)
 # Microsoft BASIC for 6502 Microprocessor - Version 1.1
 
 ## Historical Significance


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/Synqit-demo/d3a8465c-0048-4c97-94f2-a934ff52129a/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.